### PR TITLE
fixing addMutatedBy when called multiple times with the same key

### DIFF
--- a/src/add-mutated-by.js
+++ b/src/add-mutated-by.js
@@ -42,11 +42,13 @@ module.exports = function(mutatedByMap) {
 			mutatedByMap.set(mutated, root);
 		}
 
-		// retrieve or create a [key] DependencyRecord, if [key] was provided
-		if (gotKey) {
+		// create a [key] DependencyRecord if [key] was provided
+		// and Record does not already exist
+		if (gotKey && !root.mutateDependenciesForKey.get(key)) {
 			root.mutateDependenciesForKey.set(key, makeDependencyRecord());
 		}
 
+		// retrieve DependencyRecord
 		var dependencyRecord = gotKey ?
 			root.mutateDependenciesForKey.get(key) :
 			root.mutateDependenciesForValue;

--- a/test.js
+++ b/test.js
@@ -129,3 +129,52 @@ QUnit.test("key - key & value dependencies", function(assert) {
 		"undefined"
 	);
 });
+
+QUnit.test("key - two value dependencies (#15)", function(assert) {
+	var source = new SimpleMap({
+		key: "keyValue"
+	});
+	var one = new SimpleObservable("one");
+	var two = new SimpleObservable("two");
+
+	// canReflect.onValue(one, _ => source.set('key', 'three'));
+	canReflectDeps.addMutatedBy(source, "key", one);
+
+	assert.deepEqual(
+		canReflectDeps
+			.getDependencyDataOf(source, "key")
+			.whatChangesMe
+			.mutate
+			.valueDependencies,
+		new Set([ one ]),
+		"key -> Set([ one ])"
+	);
+
+	// canReflect.onValue(two, _ => source.set('key', 'four'));
+	canReflectDeps.addMutatedBy(source, "key", two);
+
+	assert.deepEqual(
+		canReflectDeps
+			.getDependencyDataOf(source, "key")
+			.whatChangesMe
+			.mutate
+			.valueDependencies,
+		new Set([ one, two ]),
+		"key -> Set([ one, two ])"
+	);
+
+	canReflectDeps.deleteMutatedBy(source, "key", one);
+
+	assert.deepEqual(
+		canReflectDeps
+			.getDependencyDataOf(source, "key")
+			.whatChangesMe
+			.mutate
+			.valueDependencies,
+		new Set([ two ]),
+		"key -> Set([ two ])"
+	);
+
+	canReflectDeps.deleteMutatedBy(source, "key", two);
+	assert.equal(typeof canReflectDeps.getDependencyDataOf(source), "undefined");
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-reflect-dependencies/issues/15.