### PR TITLE
fixes for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/canjs/can-reflect-dependencies#readme",
   "dependencies": {
+    "can-assign": "^1.3.1",
     "can-reflect": "^1.10.0",
     "can-symbol": "^1.4.1"
   },

--- a/src/get-dependency-data-of.js
+++ b/src/get-dependency-data-of.js
@@ -2,6 +2,7 @@
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 var isFunction = require("./is-function");
+var canAssign = require("can-assign");
 
 var getWhatIChangeSymbol = canSymbol.for("can.getWhatIChange");
 var getKeyDependenciesSymbol = canSymbol.for("can.getKeyDependencies");
@@ -84,9 +85,11 @@ var getWhatChangesMe = function getWhatChangesMe(mutatedByMap, obj, key) {
 		getValueDependencies(obj);
 
 	if (!isEmptyRecord(mutate) || !isEmptyRecord(derive)) {
-		return Object.assign(
-			{},
-			mutate ? { mutate: mutate } : null,
+		return canAssign(
+			canAssign(
+				{},
+				mutate ? { mutate: mutate } : null
+			),
 			derive ? { derive: derive } : null
 		);
 	}
@@ -103,9 +106,11 @@ module.exports = function(mutatedByMap) {
 		var whatIChange = gotKey ? getWhatIChange(obj, key) : getWhatIChange(obj);
 
 		if (whatChangesMe || whatIChange) {
-			return Object.assign(
-				{},
-				whatIChange ? { whatIChange: whatIChange } : null,
+			return canAssign(
+				canAssign(
+					{},
+					whatIChange ? { whatIChange: whatIChange } : null
+				),
 				whatChangesMe ? { whatChangesMe: whatChangesMe } : null
 			);
 		}

--- a/test.html
+++ b/test.html
@@ -7,7 +7,7 @@
 <body>
 	<div id="qunit"></div>
   <div id="qunit-fixture"></div>
-	<script src="./node_modules/steal/steal-sans-promises.js"
+	<script src="./node_modules/steal/steal.js"
 		main="can-reflect-dependencies/test">
 	</script>
 </body>

--- a/test.js
+++ b/test.js
@@ -83,9 +83,11 @@ QUnit.test("value - key & value dependencies", function(assert) {
 	var one = new SimpleObservable("one");
 
 	var keyDependencies = makeKeyDependencies(map, ["foo"]);
+	var valueDependencies = new Set();
+	valueDependencies.add(one);
 	var mutator = {
 		keyDependencies: keyDependencies,
-		valueDependencies: new Set([one])
+		valueDependencies: valueDependencies
 	};
 
 	// canReflect.onValue(one, _ => value.set('qux'))
@@ -93,7 +95,9 @@ QUnit.test("value - key & value dependencies", function(assert) {
 	canReflectDeps.addMutatedBy(value, mutator);
 
 	var res = canReflectDeps.getDependencyDataOf(value).whatChangesMe;
-	assert.deepEqual(res.mutate.valueDependencies, new Set([one]));
+	var expected = new Set();
+	expected.add(one);
+	assert.deepEqual(res.mutate.valueDependencies, expected);
 	assert.deepEqual(res.mutate.keyDependencies, keyDependencies);
 
 	canReflectDeps.deleteMutatedBy(value, mutator);


### PR DESCRIPTION
This makes `can-reflect-dependencies` works with IE11:
* Use ```can-assign``` instead of ```Object.assign```
* Fix `Set` instantiation